### PR TITLE
Unify main.yml

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,18 +1,5 @@
 ---
 
-- name: Sync neutron database
-  command: >-
-    neutron-db-manage --config-file /etc/neutron/neutron.conf
-    --config-file {{ openstack_neutron_controller_neutron_plugin_path }} upgrade head
-  become: True
-  become_user: neutron
-
-- name: Sync midonet database
-  command: >-
-    neutron-db-manage --subproject networking-midonet upgrade head
-  become: True
-  become_user: neutron
-
 - name: Restart neutron server
   service:
     name: 'neutron-server'

--- a/tasks/configuration_midonet.yml
+++ b/tasks/configuration_midonet.yml
@@ -9,6 +9,8 @@
     section: '{{ item.section }}'
     option: '{{ item.option }}'
     value: '{{ item.value }}'
+  notify:
+    - Restart neutron server
   with_items:
     # Database
     - section: 'database'
@@ -109,9 +111,6 @@
         {{- openstack_neutron_controller_keystone_protocol }}://
         {{- openstack_neutron_controller_keystone_hostname }}:
         {{- openstack_neutron_controller_keystone_admin_port }}/
-  notify:
-    - Restart neutron server
-    - Sync neutron database
 
 - name: Create plugin directory
   file:
@@ -140,6 +139,8 @@
   ini_file:
     dest: /etc/neutron/plugins/midonet/midonet.ini
     section: '{{ item.section }}'
+  notify:
+    - Restart neutron server
   with_items:
     - section: 'MIDONET'
       option: 'midonet_uri'
@@ -153,6 +154,43 @@
     - section: 'MIDONET'
       option: 'project_id'
       value: 'service'
+
+- name: Get current neutron database version
+  command: >-
+    neutron-db-manage
+    --config-file /etc/neutron/neutron.conf
+    --config-file {{ openstack_neutron_controller_neutron_plugin_path }}
+    current
+  always_run: True
+  become: True
+  become_user: 'neutron'
+  changed_when: neutron_db_manage_current.stdout.find('(head)') == -1
+  register: neutron_db_manage_current
+
+- name: Migrate neutron database to head version
+  command: >-
+    neutron-db-manage
+    --config-file /etc/neutron/neutron.conf
+    --config-file {{ openstack_neutron_controller_neutron_plugin_path }}
+    upgrade heads
+  become: True
+  become_user: 'neutron'
   notify:
     - Restart neutron server
-    - Sync midonet database
+  when: neutron_db_manage_current|changed
+
+- name: Get current networking-midonet database version
+  command: 'neutron-db-manage --subproject networking-midonet current'
+  always_run: True
+  become: True
+  become_user: 'neutron'
+  changed_when: neutron_db_manage_networking_midonet_current.stdout.find('(head)') == -1
+  register: neutron_db_manage_networking_midonet_current
+
+- name: Migrate networking-midonet database to head version
+  command: 'neutron-db-manage --subproject networking-midonet upgrade heads'
+  become: True
+  become_user: 'neutron'
+  notify:
+    - Restart neutron server
+  when: neutron_db_manage_networking_midonet_current|changed

--- a/tasks/configuration_ml2.yml
+++ b/tasks/configuration_ml2.yml
@@ -6,6 +6,8 @@
     section: '{{ item.section }}'
     option: '{{ item.option }}'
     value: '{{ item.value }}'
+  notify:
+    - Restart neutron server
   with_items:
     # Database
     - section: 'database'
@@ -108,11 +110,6 @@
     - section: nova
       option: password
       value: '{{ openstack_neutron_controller_nova_password }}'
-  notify:
-    - Sync neutron database
-    - Restart neutron server
-
-# FIXME: Enable services for RH
 
 - name: Link default neutron plugin
   file:
@@ -128,6 +125,8 @@
     section: '{{ item.section }}'
     option: '{{ item.option }}'
     value: '{{ item.value }}'
+  notify:
+    - Restart neutron server
   with_items:
     - section: 'ml2'
       option: 'type_drivers'
@@ -150,9 +149,6 @@
     - section: 'securitygroup'
       option: 'enable_ipset'
       value: 'True'
-  notify:
-    - Sync neutron database
-    - Restart neutron server
 
 - name: Configure the Linux Bridge agent
   ini_file:
@@ -160,6 +156,8 @@
     section: '{{ item.section }}'
     option: '{{ item.option }}'
     value: '{{ item.value }}'
+  notify:
+    - Restart linuxbridge agent
   with_items:
     - section: 'linux_bridge'
       option: 'physical_interface_mappings'
@@ -179,8 +177,6 @@
     - section: 'securitygroup'
       option: 'firewall_driver'
       value: 'neutron.agent.linux.iptables_firewall.IptablesFirewallDriver'
-  notify:
-    - Restart linuxbridge agent
 
 - name: Configure the Layer-3 agent
   ini_file:
@@ -188,6 +184,8 @@
     section: '{{ item.section }}'
     option: '{{ item.option }}'
     value: '{{ item.value }}'
+  notify:
+    - Restart neutron L3 agent
   with_items:
     - section: 'DEFAULT'
       option: 'interface_driver'
@@ -195,8 +193,6 @@
     - section: 'DEFAULT'
       option: 'external_network_bridge'
       value: ''
-  notify:
-    - Restart neutron L3 agent
 
 - name: Configure the DHCP agent
   ini_file:
@@ -204,6 +200,8 @@
     section: '{{ item.section }}'
     option: '{{ item.option }}'
     value: '{{ item.value }}'
+  notify:
+    - Restart DHCP agent
   with_items:
     - section: 'DEFAULT'
       option: 'interface_driver'
@@ -214,8 +212,6 @@
     - section: 'DEFAULT'
       option: 'enable_isolated_metadata'
       value: 'True'
-  notify:
-    - Restart DHCP agent
 
 - name: Configure the metadata agent
   ini_file:
@@ -223,6 +219,8 @@
     section: '{{ item.section }}'
     option: '{{ item.option }}'
     value: '{{ item.value }}'
+  notify:
+    - Restart metadata agent
   with_items:
     - section: 'DEFAULT'
       option: 'nova_metadata_ip'
@@ -230,5 +228,31 @@
     - section: 'DEFAULT'
       option: 'metadata_proxy_shared_secret'
       value: '{{ openstack_neutron_controller_neutron_metadata_secret }}'
+
+- name: Get current neutron database version
+  command: >-
+    neutron-db-manage
+    --config-file /etc/neutron/neutron.conf
+    --config-file {{ openstack_neutron_controller_neutron_plugin_path }}
+    current
+  always_run: True
+  become: True
+  become_user: 'neutron'
+  changed_when: neutron_db_manage_current.stdout.find('(head)') == -1
+  register: neutron_db_manage_current
+
+- name: Migrate neutron database to head version
+  command: >-
+    neutron-db-manage
+    --config-file /etc/neutron/neutron.conf
+    --config-file {{ openstack_neutron_controller_neutron_plugin_path }}
+    upgrade heads
+  become: True
+  become_user: 'neutron'
   notify:
+    - Restart neutron server
+    - Restart linuxbridge agent
+    - Restart neutron L3 agent
+    - Restart DHCP agent
     - Restart metadata agent
+  when: neutron_db_manage_current|changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,17 @@
 ---
 
 - include: facts.yml
-- include: packages.yml
-- include: configuration_{{ openstack_neutron_controller_neutron_plugin | default('ml2') }}.yml
+
+- include: packages_redhat_{{ openstack_neutron_controller_neutron_plugin }}.yml
+  when: ansible_os_family == 'RedHat'
+
+- include: packages_debian_{{ openstack_neutron_controller_neutron_plugin }}.yml
+  when: ansible_os_family == 'Debian'
+
+- include: configuration_{{ openstack_neutron_controller_neutron_plugin }}.yml
+
+- include: services.yml
+
 - meta: flush_handlers
+
 - include: sanitycheck.yml

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -1,7 +1,0 @@
----
-
-- include: packages_redhat_{{ openstack_neutron_controller_neutron_plugin | default('ml2') }}.yml
-  when: ansible_os_family == 'RedHat'
-
-- include: packages_debian_{{ openstack_neutron_controller_neutron_plugin | default('ml2') }}.yml
-  when: ansible_os_family == 'Debian'

--- a/tasks/services.yml
+++ b/tasks/services.yml
@@ -1,0 +1,19 @@
+---
+
+- name: 'Start neutron server'
+  service:
+    enabled: True
+    name: 'neutron-server'
+    state: started
+
+- name: 'Start and enable ML2 related daemons'
+  service:
+    enabled: True
+    name: '{{ item }}'
+    state: started
+  when: openstack_neutron_controller_neutron_plugin == 'ml2'
+  with_items:
+    - 'neutron-dhcp-agent'
+    - 'neutron-l3-agent'
+    - 'neutron-linuxbridge-agent'
+    - 'neutron-metadata-agent'


### PR DESCRIPTION
Unify `main.yml` to a standard set of includes, with improved service
handling, improved database migration.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
